### PR TITLE
Add a priority to the corner icon so that its position stays consistent.

### DIFF
--- a/Characters/Characters.cs
+++ b/Characters/Characters.cs
@@ -533,6 +533,7 @@ namespace Kenedia.Modules.Characters
                 Icon = AsyncTexture2D.FromAssetId(156678),
                 HoverIcon = AsyncTexture2D.FromAssetId(156679),
                 SetLocalizedTooltip = () => string.Format(strings.Toggle, $"{Name}"),
+                Priority = 51294256,
                 Parent = GameService.Graphics.SpriteScreen,
                 Visible = Settings.ShowCornerIcon.Value,
                 ClickAction = () => MainWindow?.ToggleWindow(),

--- a/Characters/manifest.json
+++ b/Characters/manifest.json
@@ -26,5 +26,5 @@
   "namespace": "Kenedia.Modules.Characters",
   "package": "Kenedia.Modules.Characters.dll",
   "url": "https://github.com/KenediaDev/Kenedia.BlishHUD",
-  "version": "1.0.24"
+  "version": "1.0.25"
 }


### PR DESCRIPTION
Adds a priority which keeps it in place next to the other sorted icons and lets the module "Bag of Holding" better keep track of it.